### PR TITLE
Add support for only signing, and not also encrypting

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.18
       - name: install actionlint
         run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
       - name: actionlint

--- a/cross_language_tests/boxer.rb
+++ b/cross_language_tests/boxer.rb
@@ -21,6 +21,9 @@ case cmd
 when "encode"
   testcase["Ciphertext"] = boxer.encode(testcase["ResponseTo"], testcase["Plaintext"])
   File.write(outfile, Base64.strict_encode64(MessagePack.pack(testcase)))
+when "sign"
+  testcase["Ciphertext"] = boxer.sign(testcase["ResponseTo"], testcase["Plaintext"])
+  File.write(outfile, Base64.strict_encode64(MessagePack.pack(testcase)))
 when "decode"
   testcase["Plaintext"] = boxer.decode(testcase["Ciphertext"]).data
   File.write(outfile, Base64.strict_encode64(MessagePack.pack(testcase)))
@@ -29,6 +32,12 @@ when "decodeunverified"
   File.write(outfile, Base64.strict_encode64(MessagePack.pack(testcase)))
 when "decodepng"
   testcase["Plaintext"] = boxer.decode_png(File.read(testcase["PngFile"])).data
+  File.write(outfile, Base64.strict_encode64(MessagePack.pack(testcase)))
+when "verify"
+  testcase["Plaintext"] = boxer.decode(testcase["Ciphertext"]).signedtext
+  File.write(outfile, Base64.strict_encode64(MessagePack.pack(testcase)))
+when "verifyunverified"
+  testcase["Plaintext"] = boxer.decode_unverified(testcase["Ciphertext"]).signedtext
   File.write(outfile, Base64.strict_encode64(MessagePack.pack(testcase)))
 when "spew"
   pp testcase

--- a/test/krypto/boxer_test.rb
+++ b/test/krypto/boxer_test.rb
@@ -40,5 +40,19 @@ class TestKryptoBoxer < Minitest::Test
       assert_raises { BARE_MALLORYBOX.decode(box) }
       assert_raises { BARE_MALLORYBOX.decode_unverified(box) }
     end
+
+    define_method("test_can_verify: #{name}") do
+      box = ALICEBOX.sign(SecureRandom.uuid, message)
+
+      assert_equal(message, BOBBOX.decode(box).signedtext)
+      assert_equal(message, BOBBOX.decode_unverified(box).signedtext)
+      assert_equal(message, BARE_BOBBOX.decode_unverified(box).signedtext)
+    end
+
+    define_method("test_cannot_verify: #{name}") do
+      box = ALICEBOX.sign(SecureRandom.uuid, message)
+
+      assert_raises { BARE_BOBBOX.decode(box) }
+    end
   end
 end


### PR DESCRIPTION
This adds a `Signedtext` field to the Inner struct, and plumbs through methods to sign (but not encrypt) the box.

There is no special verify routine, that's part of `decode`

As a small bonus, this moves how the returned sender data is generated. Instead of being applied by the sender, it's extracted from the envelope. 