### PR TITLE
Change call semantics on ruby challenges

### DIFF
--- a/lib/krypto/boxer.rb
+++ b/lib/krypto/boxer.rb
@@ -84,7 +84,7 @@ module Krypto
     def decode(data, verify: true, raw: false, png: false)
       data = unpng(data) if png
       data = Base64.strict_decode64(data) unless raw || png
-      outer = Outer.new(MessagePack.unpack(data))
+      outer = Outer.new(MessagePack.unpack(data).slice(*OUTER_FIELDS.map(&:to_s)))
 
       raise "Bag Signature" if verify && !::Krypto::Rsa.verify(@counterparty, outer.signature, outer.inner)
 

--- a/test/krypto/challenge_test.rb
+++ b/test/krypto/challenge_test.rb
@@ -14,7 +14,7 @@ class TestKryptoChallenge < Minitest::Test
     challenge, private_encryption_key = ::Krypto::Challenge.generate(CHALLENGER_KEY, CHALLENGE_ID, CHALLENGE_DATA)
 
     challenger_public_key = OpenSSL::PKey::EC.new(CHALLENGER_KEY.public_to_pem)
-    response = ::Krypto::Challenge.respond(RESPONDER_KEY, challenger_public_key, challenge, RESPONDER_DATA)
+    response = ::Krypto::Challenge.respond(RESPONDER_KEY, challenger_public_key, challenge) { RESPONDER_DATA }
 
     assert_equal(response.challengeId, CHALLENGE_ID)
 

--- a/test/krypto/challenge_test.rb
+++ b/test/krypto/challenge_test.rb
@@ -12,13 +12,15 @@ class TestKryptoChallenge < Minitest::Test
 
   def test_challenge
     challenge, private_encryption_key = ::Krypto::Challenge.generate(CHALLENGER_KEY, CHALLENGE_ID, CHALLENGE_DATA)
+    challenge_packed = Base64.strict_encode64(MessagePack.pack(challenge))
 
     challenger_public_key = OpenSSL::PKey::EC.new(CHALLENGER_KEY.public_to_pem)
-    response = ::Krypto::Challenge.respond(RESPONDER_KEY, challenger_public_key, challenge) { RESPONDER_DATA }
+    response = ::Krypto::Challenge.respond(RESPONDER_KEY, challenger_public_key, challenge_packed) { RESPONDER_DATA }
 
     assert_equal(response.challengeId, CHALLENGE_ID)
 
-    opened_response = ::Krypto::Challenge.open_response(private_encryption_key, response)
+    response_packed = MessagePack.pack(response)
+    opened_response = ::Krypto::Challenge.open_response(private_encryption_key, response_packed)
 
     assert_equal(CHALLENGE_DATA, opened_response.challengeData)
     assert_equal(RESPONDER_DATA, opened_response.responseData)


### PR DESCRIPTION
This has a couple of changes to the call semantics.

First, it adds some `slices` to how we create the internal objects. This allows for compatibility between the old boxer and the new challenger.

Second, it takes `response_data` out of the method signature for `respond`, and instead uses `yield`. This allows for a very ruby style interface. The caller calls `respond` and passes a block which generates `response_data`. (It's a bit like passing an interface, Which is probably what the go side should be doing)

Third, it changes a bunch of challenge interfaces to take base64 or packed things, and not objects. I don't think the Outer vs Inner objects should matter to the caller, and I'd rather not expose them. I'm not sure I'm consistent enough about what's base64 vs packed, I was being a little sloppy in aiming for compatibility with the existing k2 code.

Somewhat unfortunate, is that (2) is a bit hard to see for (3)