### PR TITLE
james/sig2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,8 +25,11 @@ linters:
     - varcheck
 
 linters-settings:
+  goanalysis_metalinter:
+    exclude:
+      - github.com/google/go-tpm-tools/simulator/internal
   errcheck:
-    ignore: github.com/go-kit/kit/log:Log
+    ignore: github.com/go-kit/kit/log:Log, github.com/google/go-tpm-tools/simulator/internal
   gofmt:
     simplify: false
 

--- a/cross_language_tests/challenge.rb
+++ b/cross_language_tests/challenge.rb
@@ -34,6 +34,7 @@ when "generate"
 
 when "respond"
   signing_key = OpenSSL::PKey::EC.generate("prime256v1")
+  signing_key_2 = OpenSSL::PKey::EC.generate("prime256v1")
   counter_party = OpenSSL::PKey::EC.new(test_case["ChallengerPublicKey"])
   outer_challenge = Krypto::Challenge::OuterChallenge.new(MessagePack.unpack(test_case["ChallengePack"]))
 
@@ -48,6 +49,7 @@ when "respond"
       MessagePack.pack(
         outer_challenge.respond(
           signing_key,
+          signing_key_2,
           data
         )
       )

--- a/cross_language_tests/challenge_cross_test.go
+++ b/cross_language_tests/challenge_cross_test.go
@@ -312,8 +312,10 @@ func tamperWithChallenge(t *testing.T, challengeBytes []byte) []byte {
 func tamperWithResponse(t *testing.T, challengeBytes, responseBytes []byte) []byte {
 	malloryKey := ecdsaKey(t)
 
-	publicPem, err := echelper.PublicEcdsaKeyToPem(&malloryKey.PublicKey)
+	malloryKeyDerBytes, err := x509.MarshalPKIXPublicKey(&malloryKey.PublicKey)
 	require.NoError(t, err)
+
+	malloryB64Der := base64.StdEncoding.EncodeToString(malloryKeyDerBytes)
 
 	outerChallenge, err := challenge.UnmarshalChallenge(challengeBytes)
 	require.NoError(t, err)
@@ -322,8 +324,8 @@ func tamperWithResponse(t *testing.T, challengeBytes, responseBytes []byte) []by
 	require.NoError(t, msgpack.Unmarshal(outerChallenge.Msg, &innerChallenge))
 
 	innerResponseBytes, err := msgpack.Marshal(challenge.InnerResponse{
-		PublicSigningKey:  publicPem,
-		PublicSigningKey2: publicPem,
+		PublicSigningKey:  []byte(malloryB64Der),
+		PublicSigningKey2: []byte(malloryB64Der),
 		ChallengeData:     innerChallenge.ChallengeData,
 		ResponseData:      []byte("evil response data"),
 		Timestamp:         time.Now().Unix(),

--- a/cross_language_tests/challenge_cross_test.go
+++ b/cross_language_tests/challenge_cross_test.go
@@ -1,6 +1,7 @@
 package cross_language_tests
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -16,7 +17,9 @@ import (
 	"time"
 
 	"github.com/kolide/kit/ulid"
+	"github.com/kolide/krypto"
 	"github.com/kolide/krypto/pkg/challenge"
+	"github.com/kolide/krypto/pkg/echelper"
 	"github.com/stretchr/testify/require"
 	"github.com/vmihailenco/msgpack/v5"
 	"golang.org/x/crypto/nacl/box"
@@ -33,187 +36,193 @@ type rubyChallengeCmd struct {
 	ResponseData          []byte
 }
 
-func TestChallengeRuby(t *testing.T) {
+func TestChallenge_RubyGenerate_GoRespondPng(t *testing.T) {
 	t.Parallel()
 
-	testChallenges := [][]byte{
-		[]byte("a"),
-		[]byte("Hello World"),
-		[]byte("This isn't super long, but it's at least a little long?"),
-		[]byte(randomString(t, 1024)),
-		mkrand(t, 1024),
-		[]byte(randomString(t, 4096)),
-		mkrand(t, 4096),
-	}
+	//nolint: paralleltest
+	for _, challengeData := range testChallenges(t) {
+		dir := t.TempDir()
 
-	responderData := []byte("here is some data about the responder")
+		rubyPrivateSigningKey := ecdsaKey(t)
+		challengeId := []byte(ulid.New())
+		requestData := []byte(ulid.New())
 
-	for _, testChallenge := range testChallenges {
-		testChallenge := testChallenge
+		var challengeOuterBoxBytes []byte
 
-		t.Run("Ruby challenges, Go responds with png", func(t *testing.T) {
-			t.Parallel()
-
-			rubyPrivateSigningKey := ecdsaKey(t)
-			responderKey := ecdsaKey(t)
-			dir := t.TempDir()
-
-			challengeId := []byte(ulid.New())
-			requestData := []byte(ulid.New())
-
+		t.Run("ruby creates challenge", func(t *testing.T) {
 			rubyChallengeCmdData := rubyChallengeCmd{
 				RubyPrivateSigningKey: privateEcKeyToPem(t, rubyPrivateSigningKey),
-				ChallengeData:         testChallenge,
+				ChallengeData:         challengeData,
 				ChallengeId:           challengeId,
 				RequestData:           requestData,
 			}
 
 			out, err := rubyChallengeExec("generate", dir, rubyChallengeCmdData)
 			require.NoError(t, err, string(out))
+			challengeOuterBoxBytes = out
+		})
 
-			challengeBox, err := challenge.UnmarshalChallenge(out)
-			require.NoError(t, err, string(out))
-
-			require.NoError(t, challengeBox.Verify(rubyPrivateSigningKey.PublicKey))
-
-			response, err := challengeBox.RespondPng(responderKey, responderData)
+		t.Run("go receives tampered with challenge and fails to verify", func(t *testing.T) {
+			outerChallenge, err := challenge.UnmarshalChallenge(tamperWithChallenge(t, challengeOuterBoxBytes))
 			require.NoError(t, err)
 
-			rubyChallengeCmdData = rubyChallengeCmd{
-				ResponsePack: response,
+			require.ErrorContains(t, outerChallenge.Verify(rubyPrivateSigningKey.PublicKey), "invalid signature", "should get an eror due to tampering")
+		})
+
+		var outerResponsePngBytes []byte
+		responderData := []byte(ulid.New())
+
+		t.Run("go receives legit challenge and creates response png", func(t *testing.T) {
+			challengeOuterBox, err := challenge.UnmarshalChallenge(challengeOuterBoxBytes)
+			require.NoError(t, err)
+
+			responderPrivateSigningKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			require.NoError(t, err)
+
+			responderPrivateSigningKey2, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			require.NoError(t, err)
+
+			// try to get info before verifying, shouldn't work
+			require.Empty(t, challengeOuterBox.RequestData())
+			require.Equal(t, challengeOuterBox.Timestamp(), int64(-1))
+
+			// try to response before verifying, shouldn't work
+			_, err = challengeOuterBox.Respond(responderPrivateSigningKey, responderPrivateSigningKey2, responderData)
+			require.Error(t, err)
+
+			// try to verify with bad key
+			malloryPrivateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			require.NoError(t, err)
+			require.Error(t, challengeOuterBox.Verify(malloryPrivateKey.PublicKey))
+
+			// verify with correct key
+			require.NoError(t, challengeOuterBox.Verify(rubyPrivateSigningKey.PublicKey))
+
+			// verify data
+			require.WithinDuration(t, time.Now(), time.Unix(challengeOuterBox.Timestamp(), 0), time.Second*5)
+			require.Equal(t, requestData, challengeOuterBox.RequestData())
+
+			// generate response with nil signer2
+			_, err = challengeOuterBox.RespondPng(responderPrivateSigningKey, nil, responderData)
+			require.NoError(t, err)
+
+			// generate response
+			outerResponsePngBytes, err = challengeOuterBox.RespondPng(responderPrivateSigningKey, responderPrivateSigningKey2, responderData)
+			require.NoError(t, err)
+		})
+
+		t.Run("ruby receives tampered with response, fails to verify", func(t *testing.T) {
+			rubyChallengeCmdData := rubyChallengeCmd{
+				ResponsePack: tamperWithPngResponse(t, challengeOuterBoxBytes, outerResponsePngBytes),
+			}
+
+			out, err := rubyChallengeExec("open_response_png", dir, rubyChallengeCmdData)
+			require.Error(t, err)
+			require.Contains(t, string(out), "invalid signature")
+		})
+
+		t.Run("ruby handles legit response", func(t *testing.T) {
+			rubyChallengeCmdData := rubyChallengeCmd{
+				ResponsePack: outerResponsePngBytes,
 			}
 
 			// make sure the challenge id persisted
-			responseBox, err := challenge.UnmarshalResponsePng(response)
-			require.NoError(t, err, string(response))
+			responseBox, err := challenge.UnmarshalResponsePng(outerResponsePngBytes)
+			require.NoError(t, err)
 			require.Equal(t, challengeId, responseBox.ChallengeId)
 
-			out, err = rubyChallengeExec("open_response_png", dir, rubyChallengeCmdData)
+			out, err := rubyChallengeExec("open_response_png", dir, rubyChallengeCmdData)
 			require.NoError(t, err, string(out))
 
 			var innerResponse challenge.InnerResponse
 			require.NoError(t, msgpack.Unmarshal(out, &innerResponse))
 
-			require.Equal(t, testChallenge, innerResponse.ChallengeData)
+			require.Equal(t, challengeData, innerResponse.ChallengeData)
 			require.Equal(t, responderData, innerResponse.ResponseData)
-			require.WithinDuration(t, time.Now(), time.Unix(innerResponse.Timestamp, 0), time.Second*5)
-		})
-
-		t.Run("Go challenges, Ruby responds", func(t *testing.T) {
-			t.Parallel()
-
-			challengerKey := ecdsaKey(t)
-			dir := t.TempDir()
-
-			challengeId := []byte(ulid.New())
-			requestData := []byte(ulid.New())
-
-			generatedChallenge, privEncryptionKey, err := challenge.Generate(challengerKey, challengeId, testChallenge, requestData)
-			require.NoError(t, err)
-
-			rubyChallengeCmdData := rubyChallengeCmd{
-				ChallengerPublicKey: publicEcKeyToPem(t, &challengerKey.PublicKey),
-				ChallengePack:       generatedChallenge,
-				ResponseData:        responderData,
-			}
-
-			out, err := rubyChallengeExec("respond", dir, rubyChallengeCmdData)
-			require.NoError(t, err, string(out))
-
-			responseBox, err := challenge.UnmarshalResponse(out)
-			require.NoError(t, err, string(out))
-
-			innerResponse, err := responseBox.Open(*privEncryptionKey)
-			require.NoError(t, err)
-
-			require.Equal(t, testChallenge, innerResponse.ChallengeData)
-			require.Equal(t, responderData, innerResponse.ResponseData)
-			require.Equal(t, challengeId, responseBox.ChallengeId)
 			require.WithinDuration(t, time.Now(), time.Unix(innerResponse.Timestamp, 0), time.Second*5)
 		})
 	}
 }
 
-func TestChallengeRubyTampering(t *testing.T) {
+func TestChallenge_GoGenerate_RubyRespond(t *testing.T) {
 	t.Parallel()
 
-	testChallenge := []byte("this is the original message")
-	responderData := []byte("here is some data about the responder")
-
-	t.Run("Ruby challenges, Go responds, Tamper With Challenge", func(t *testing.T) {
-		t.Parallel()
-
-		rubyPrivateSignignKey := ecdsaKey(t)
+	//nolint: paralleltest
+	for _, challengeData := range testChallenges(t) {
 		dir := t.TempDir()
+
+		goPrivateSigningKey := ecdsaKey(t)
 		challengeId := []byte(ulid.New())
 		requestData := []byte(ulid.New())
 
-		rubyChallengeCmdData := rubyChallengeCmd{
-			RubyPrivateSigningKey: privateEcKeyToPem(t, rubyPrivateSignignKey),
-			ChallengeData:         testChallenge,
-			ChallengeId:           challengeId,
-			RequestData:           requestData,
-		}
+		var challengeOuterBoxBytes []byte
+		var challengePrivateEncryptionKey *[32]byte
 
-		out, err := rubyChallengeExec("generate", dir, rubyChallengeCmdData)
-		require.NoError(t, err, string(out))
+		t.Run("go creates challenge", func(t *testing.T) {
+			out, key, err := challenge.Generate(goPrivateSigningKey, challengeId, challengeData, requestData)
+			require.NoError(t, err, string(challengeOuterBoxBytes))
 
-		// open up the box and change the inner message
-		challengeBox, err := challenge.UnmarshalChallenge(out)
-		require.NoError(t, err, string(out))
-
-		tamperPub, _, err := box.GenerateKey(rand.Reader)
-		require.NoError(t, err)
-
-		tamperedInner, err := msgpack.Marshal(challenge.InnerChallenge{
-			PublicEncryptionKey: *tamperPub,
-			ChallengeData:       testChallenge,
+			challengeOuterBoxBytes = out
+			challengePrivateEncryptionKey = key
 		})
-		require.NoError(t, err)
 
-		challengeBox.Msg = tamperedInner
+		var outerResponseBytes []byte
+		responderData := []byte(ulid.New())
 
-		// should fail verification now
-		require.Error(t, challengeBox.Verify(rubyPrivateSignignKey.PublicKey))
-	})
-
-	t.Run("Go challenges, Ruby responds, Tamper With Challenge", func(t *testing.T) {
-		t.Parallel()
-
-		challengerKey := ecdsaKey(t)
-		dir := t.TempDir()
-
-		challengeBytes, _, err := challenge.Generate(challengerKey, []byte(ulid.New()), testChallenge, []byte(ulid.New()))
-		require.NoError(t, err)
-
-		tamperPub, _, err := box.GenerateKey(rand.Reader)
-		require.NoError(t, err)
-
-		tamperedInner, err := msgpack.Marshal(challenge.InnerChallenge{
-			PublicEncryptionKey: *tamperPub,
-			ChallengeData:       testChallenge,
+		t.Run("ruby receives tampered with challenge and and fails to verify", func(t *testing.T) {
+			rubyChallengeCmdData := rubyChallengeCmd{
+				ChallengerPublicKey: publicEcKeyToPem(t, &goPrivateSigningKey.PublicKey),
+				ChallengePack:       tamperWithChallenge(t, challengeOuterBoxBytes),
+				ResponseData:        responderData,
+			}
+			out, err := rubyChallengeExec("respond", dir, rubyChallengeCmdData)
+			require.Error(t, err, string(outerResponseBytes))
+			require.Contains(t, string(out), "verification failed")
 		})
-		require.NoError(t, err)
 
-		// open up the box and add a new inner message
-		challengeBox, err := challenge.UnmarshalChallenge(challengeBytes)
-		require.NoError(t, err, string(challengeBytes))
+		t.Run("ruby receives challenge and creates response", func(t *testing.T) {
+			rubyChallengeCmdData := rubyChallengeCmd{
+				ChallengerPublicKey: publicEcKeyToPem(t, &goPrivateSigningKey.PublicKey),
+				ChallengePack:       challengeOuterBoxBytes,
+				ResponseData:        responderData,
+			}
+			out, err := rubyChallengeExec("respond", dir, rubyChallengeCmdData)
+			require.NoError(t, err, string(outerResponseBytes))
 
-		challengeBox.Msg = tamperedInner
+			outerResponseBytes = out
+		})
 
-		challengeBytes, err = challengeBox.Marshal()
-		require.NoError(t, err)
+		t.Run("go recives tampered with response and fails to verify", func(t *testing.T) {
+			outerResponse, err := challenge.UnmarshalResponse(tamperWithResponse(t, challengeOuterBoxBytes, outerResponseBytes))
+			require.NoError(t, err)
 
-		rubyChallengeCmdData := rubyChallengeCmd{
-			ChallengerPublicKey: publicEcKeyToPem(t, &challengerKey.PublicKey),
-			ChallengePack:       challengeBytes,
-			ResponseData:        responderData,
-		}
+			_, err = outerResponse.Open(*challengePrivateEncryptionKey)
+			require.Error(t, err)
+		})
 
-		out, err := rubyChallengeExec("respond", dir, rubyChallengeCmdData)
-		require.Error(t, err, string(out))
-		require.Contains(t, string(out), "challenge verification failed")
-	})
+		t.Run("go handles legit response", func(t *testing.T) {
+			outerResponse, err := challenge.UnmarshalResponse(outerResponseBytes)
+			require.NoError(t, err)
+
+			// verify id
+			require.Equal(t, challengeId, outerResponse.ChallengeId)
+
+			// try to open with a bad key
+			_, malloryPrivKey, err := box.GenerateKey(rand.Reader)
+			require.NoError(t, err)
+			_, err = outerResponse.Open(*malloryPrivKey)
+			require.Error(t, err)
+
+			// open with legit key
+			innerResponse, err := outerResponse.Open(*challengePrivateEncryptionKey)
+			require.NoError(t, err)
+
+			// verify data
+			require.Equal(t, challengeData, innerResponse.ChallengeData)
+			require.Equal(t, responderData, innerResponse.ResponseData)
+			require.WithinDuration(t, time.Now(), time.Unix(innerResponse.Timestamp, 0), time.Second*5)
+		})
+	}
 }
 
 // #nosec G306 -- Need readable files
@@ -268,4 +277,82 @@ func publicEcKeyToPem(t *testing.T, public *ecdsa.PublicKey) []byte {
 	bytes, err := x509.MarshalPKIXPublicKey(public)
 	require.NoError(t, err)
 	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: bytes})
+}
+
+func testChallenges(t *testing.T) [][]byte {
+	return [][]byte{
+		[]byte("a"),
+		[]byte("Hello World"),
+		[]byte("This isn't super long, but it's at least a little long?"),
+		[]byte(randomString(t, 1024)),
+		mkrand(t, 1024),
+		[]byte(randomString(t, 4096)),
+		mkrand(t, 4096),
+	}
+}
+
+func tamperWithChallenge(t *testing.T, challengeBytes []byte) []byte {
+	challengeBox, err := challenge.UnmarshalChallenge(challengeBytes)
+	require.NoError(t, err)
+
+	var innerChallenge challenge.InnerChallenge
+	require.NoError(t, msgpack.Unmarshal(challengeBox.Msg, &innerChallenge))
+
+	innerChallenge.RequestData = []byte("do something evil!")
+
+	challengeBox.Msg, err = msgpack.Marshal(innerChallenge)
+	require.NoError(t, err)
+
+	tamperedChallengeOuterBoxBytes, err := challengeBox.Marshal()
+	require.NoError(t, err)
+
+	return tamperedChallengeOuterBoxBytes
+}
+
+func tamperWithResponse(t *testing.T, challengeBytes, responseBytes []byte) []byte {
+	malloryKey := ecdsaKey(t)
+
+	publicPem, err := echelper.PublicEcdsaKeyToPem(&malloryKey.PublicKey)
+	require.NoError(t, err)
+
+	outerChallenge, err := challenge.UnmarshalChallenge(challengeBytes)
+	require.NoError(t, err)
+
+	var innerChallenge challenge.InnerChallenge
+	require.NoError(t, msgpack.Unmarshal(outerChallenge.Msg, &innerChallenge))
+
+	innerResponseBytes, err := msgpack.Marshal(challenge.InnerResponse{
+		PublicSigningKey:  publicPem,
+		PublicSigningKey2: publicPem,
+		ChallengeData:     innerChallenge.ChallengeData,
+		ResponseData:      []byte("evil response data"),
+		Timestamp:         time.Now().Unix(),
+	})
+	require.NoError(t, err)
+
+	// generate our own keys
+	naclBox, pubKey, err := echelper.SealNaCl(innerResponseBytes, &innerChallenge.PublicEncryptionKey)
+	require.NoError(t, err)
+
+	outerResponse, err := challenge.UnmarshalResponse(responseBytes)
+	require.NoError(t, err)
+
+	outerResponse.PublicEncryptionKey = *pubKey
+	outerResponse.Msg = naclBox
+
+	tamperedBytes, err := msgpack.Marshal(outerResponse)
+	require.NoError(t, err)
+
+	return tamperedBytes
+}
+
+func tamperWithPngResponse(t *testing.T, challengeBytes, pngResponseBytes []byte) []byte {
+	in := bytes.NewBuffer(pngResponseBytes)
+	var out bytes.Buffer
+	require.NoError(t, krypto.FromPng(in, &out))
+
+	var pngBuf bytes.Buffer
+	require.NoError(t, krypto.ToPng(&pngBuf, tamperWithResponse(t, challengeBytes, out.Bytes())))
+
+	return pngBuf.Bytes()
 }

--- a/lib/krypto/challenge.rb
+++ b/lib/krypto/challenge.rb
@@ -62,15 +62,15 @@ module Krypto
       def respond(signing_key, signing_key_2, response_data)
         raise "No inner. Unverified?" unless @inner
 
-        public_signing_key_2_pem = ""
+        public_signing_key_2_der = ""
         if !signing_key_2.nil?
-          public_signing_key_2_pem = signing_key_2.public_to_pem
+          public_signing_key_2_der = Base64.strict_encode64(signing_key_2.public_to_der)
         end
 
         msg = MessagePack.pack(
           Krypto::ChallengeResponse::InnerResponse.new(
-            publicSigningKey: signing_key.public_to_pem,
-            publicSigningKey2: public_signing_key_2_pem,
+            publicSigningKey: Base64.strict_encode64(signing_key.public_to_der),
+            publicSigningKey2: public_signing_key_2_der,
             challengeData: @inner.challengeData,
             responseData: response_data,
             timestamp: Time.now.to_i

--- a/lib/krypto/challenge.rb
+++ b/lib/krypto/challenge.rb
@@ -57,6 +57,8 @@ module Krypto
         @inner&.requestData
       end
 
+      # respond creates a reponse to the challenge. It accepts 2 keys to sign
+      # the response with, the second may be nil.
       def respond(signing_key, signing_key_2, response_data)
         raise "No inner. Unverified?" unless @inner
 

--- a/lib/krypto/challenge.rb
+++ b/lib/krypto/challenge.rb
@@ -62,9 +62,10 @@ module Krypto
       def respond(signing_key, signing_key_2, response_data)
         raise "No inner. Unverified?" unless @inner
 
-        public_signing_key_2_der = ""
-        if !signing_key_2.nil?
-          public_signing_key_2_der = Base64.strict_encode64(signing_key_2.public_to_der)
+        public_signing_key_2_der = if !signing_key_2.nil?
+          Base64.strict_encode64(signing_key_2.public_to_der)
+        else
+          ""
         end
 
         msg = MessagePack.pack(
@@ -80,9 +81,10 @@ module Krypto
         sig = Krypto::Ec.sign(signing_key, msg)
         private_encryption_key = RbNaCl::PrivateKey.generate
 
-        sig2 = ""
-        if !signing_key_2.nil?
-          sig2 = Krypto::Ec.sign(signing_key_2, msg)
+        sig2 = if !signing_key_2.nil?
+          Krypto::Ec.sign(signing_key_2, msg)
+        else
+          ""
         end
 
         box = RbNaCl::SimpleBox.from_keypair(@inner.publicEncryptionKey, private_encryption_key)

--- a/lib/krypto/challenge_response.rb
+++ b/lib/krypto/challenge_response.rb
@@ -33,7 +33,7 @@ module Krypto
         # If we don't have a signature 2 or a public signing key 2, return what we have
         if sig2.nil? || sig2.empty?
           # if there is no sig2, set public signing key 2 to nil just in case so that
-          # the consumer does not fasly assume it was used to perform a signature
+          # the consumer does not falsely assume it was used to perform a signature
           inner.publicSigningKey2 = nil
           return inner
         end
@@ -49,15 +49,9 @@ module Krypto
       end
 
       def self.verify_with_key_bytes(key_bytes, signature, data)
-        if key_bytes.start_with?("-----BEGIN PUBLIC KEY-----")
-          key = OpenSSL::PKey::EC.new(key_bytes)
-          raise "invalid signature" unless Krypto::Ec.verify(key, signature, data)
-          return
-        end
-
-        key = OpenSSL::PKey::EC.new(Base64.strict_decode64(key_bytes))
+        key_bytes = Base64.strict_decode64(key_bytes) unless key_bytes.start_with?("-----BEGIN PUBLIC KEY-----")
+        key = OpenSSL::PKey::EC.new(key_bytes)
         raise "invalid signature" unless Krypto::Ec.verify(key, signature, data)
-        nil
       end
     end
 

--- a/lib/krypto/challenge_response.rb
+++ b/lib/krypto/challenge_response.rb
@@ -54,10 +54,9 @@ module Krypto
 
         key = OpenSSL::PKey::EC.new(Base64.strict_decode64(key_bytes))
         raise "invalid signature" unless Krypto::Ec.verify(key, signature, data)
-        return
+        nil
       end
     end
-
 
     INNER_RESPONSE_FIELDS = %i[publicSigningKey publicSigningKey2 challengeData responseData timestamp].freeze
     class InnerResponse < Struct.new(*INNER_RESPONSE_FIELDS, keyword_init: true)

--- a/lib/krypto/challenge_response.rb
+++ b/lib/krypto/challenge_response.rb
@@ -32,6 +32,9 @@ module Krypto
 
         # If we don't have a signature 2 or a public signing key 2, return what we have
         if sig2.nil? || sig2.empty?
+          # if there is no sig2, set public signing key 2 to nil just in case so that
+          # the consumer does not fasly assume it was used to perform a signature
+          inner.publicSigningKey2 = nil
           return inner
         end
 

--- a/pkg/challenge/challenge.go
+++ b/pkg/challenge/challenge.go
@@ -54,6 +54,7 @@ func (o *OuterChallenge) Marshal() ([]byte, error) {
 	return msgpack.Marshal(o)
 }
 
+// Respond creates a response to the challenge. It accepts keys for signing, the second one may be nil.
 func (o *OuterChallenge) Respond(signer crypto.Signer, signer2 crypto.Signer, responseData []byte) ([]byte, error) {
 	if o.innerChallenge == nil {
 		return nil, fmt.Errorf("no inner. unverified?")

--- a/pkg/challenge/challenge_test.go
+++ b/pkg/challenge/challenge_test.go
@@ -7,22 +7,23 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kolide/kit/ulid"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/nacl/box"
 )
 
-func TestChallenge(t *testing.T) {
+func TestChallengeHappyPath(t *testing.T) {
 	t.Parallel()
 
 	challengerPrivateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
-	challengeId := []byte("this is the challeng id")
-	challengeData := []byte("this is a challenge")
-	requestData := []byte("this is the request data")
-	responderData := []byte("this is some responder data")
+	challengeId := []byte(ulid.New())
+	challengeData := []byte(ulid.New())
+	requestData := []byte(ulid.New())
 
 	var challengeOuterBoxBytes []byte
+	var challengeResponsePngBytesSingleSigner []byte
 	var challengePrivateEncryptionKey *[32]byte
 
 	//nolint: paralleltest
@@ -32,7 +33,8 @@ func TestChallenge(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	var outerResponsePngBytes []byte
+	var outerResponsePngBytesDoubleSigner []byte
+	responderData := []byte(ulid.New())
 
 	//nolint: paralleltest
 	t.Run("responder receives challenge and creates response", func(t *testing.T) {
@@ -42,12 +44,15 @@ func TestChallenge(t *testing.T) {
 		responderPrivateSigningKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		require.NoError(t, err)
 
+		responderPrivateSigningKey2, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+
 		// try to get info before verifying, shouldn't work
 		require.Empty(t, challengeOuterBox.RequestData())
 		require.Equal(t, challengeOuterBox.Timestamp(), int64(-1))
 
 		// try to response before verifying, shouldn't work
-		_, err = challengeOuterBox.Respond(responderPrivateSigningKey, responderData)
+		_, err = challengeOuterBox.Respond(responderPrivateSigningKey, responderPrivateSigningKey2, responderData)
 		require.Error(t, err)
 
 		// try to verify with bad key
@@ -62,32 +67,38 @@ func TestChallenge(t *testing.T) {
 		require.WithinDuration(t, time.Now(), time.Unix(challengeOuterBox.Timestamp(), 0), time.Second*5)
 		require.Equal(t, requestData, challengeOuterBox.RequestData())
 
+		// generate response with nil signer2
+		challengeResponsePngBytesSingleSigner, err = challengeOuterBox.RespondPng(responderPrivateSigningKey, nil, responderData)
+		require.NoError(t, err)
+
 		// generate response
-		outerResponsePngBytes, err = challengeOuterBox.RespondPng(responderPrivateSigningKey, responderData)
+		outerResponsePngBytesDoubleSigner, err = challengeOuterBox.RespondPng(responderPrivateSigningKey, responderPrivateSigningKey2, responderData)
 		require.NoError(t, err)
 	})
 
 	//nolint: paralleltest
 	t.Run("challenger handles response", func(t *testing.T) {
-		outerResponse, err := UnmarshalResponsePng(outerResponsePngBytes)
-		require.NoError(t, err)
+		for _, responsePngBytes := range [][]byte{challengeResponsePngBytesSingleSigner, outerResponsePngBytesDoubleSigner} {
+			outerResponse, err := UnmarshalResponsePng(responsePngBytes)
+			require.NoError(t, err)
 
-		// verify id
-		require.Equal(t, challengeId, outerResponse.ChallengeId)
+			// verify id
+			require.Equal(t, challengeId, outerResponse.ChallengeId)
 
-		// try to open with a bad key
-		_, malloryPrivKey, err := box.GenerateKey(rand.Reader)
-		require.NoError(t, err)
-		_, err = outerResponse.Open(*malloryPrivKey)
-		require.Error(t, err)
+			// try to open with a bad key
+			_, malloryPrivKey, err := box.GenerateKey(rand.Reader)
+			require.NoError(t, err)
+			_, err = outerResponse.Open(*malloryPrivKey)
+			require.Error(t, err)
 
-		// open with legit key
-		innerResponse, err := outerResponse.Open(*challengePrivateEncryptionKey)
-		require.NoError(t, err)
+			// open with legit key
+			innerResponse, err := outerResponse.Open(*challengePrivateEncryptionKey)
+			require.NoError(t, err)
 
-		// verify data
-		require.Equal(t, challengeData, innerResponse.ChallengeData)
-		require.Equal(t, responderData, innerResponse.ResponseData)
-		require.WithinDuration(t, time.Now(), time.Unix(innerResponse.Timestamp, 0), time.Second*5)
+			// verify data
+			require.Equal(t, challengeData, innerResponse.ChallengeData)
+			require.Equal(t, responderData, innerResponse.ResponseData)
+			require.WithinDuration(t, time.Now(), time.Unix(innerResponse.Timestamp, 0), time.Second*5)
+		}
 	})
 }

--- a/pkg/challenge/challenge_test.go
+++ b/pkg/challenge/challenge_test.go
@@ -152,7 +152,7 @@ func TestVerifyWithKeyBytes(t *testing.T) {
 				key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 				require.NoError(t, err)
 
-				keyBytes, err = publicEcdsaToDer(&key.PublicKey)
+				keyBytes, err = echelper.PublicEcdsaToB64Der(&key.PublicKey)
 				require.NoError(t, err)
 
 				msg = []byte(ulid.New())
@@ -214,7 +214,7 @@ func TestSignWithTimeout(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := signWithTimeout(tt.signerFunc(), []byte(ulid.New()))
+			_, err := echelper.SignWithTimeout(tt.signerFunc(), []byte(ulid.New()), signingTimeoutDuration, signingTimeoutInterval)
 			if tt.errString == "" {
 				require.NoError(t, err)
 				return

--- a/pkg/challenge/challenge_test.go
+++ b/pkg/challenge/challenge_test.go
@@ -28,9 +28,10 @@ func TestChallengeHappyPath(t *testing.T) {
 	challengeData := []byte(ulid.New())
 	requestData := []byte(ulid.New())
 
-	var challengeOuterBoxBytes []byte
-	var challengeResponsePngBytesSingleSigner []byte
-	var challengePrivateEncryptionKey *[32]byte
+	var (
+		challengeOuterBoxBytes        []byte
+		challengePrivateEncryptionKey *[32]byte
+	)
 
 	//nolint: paralleltest
 	t.Run("challenger creates challenge", func(t *testing.T) {
@@ -43,7 +44,11 @@ func TestChallengeHappyPath(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	var outerResponsePngBytesDoubleSigner []byte
+	var (
+		challengeResponsePngBytesSingleSigner []byte
+		challengeResponsePngBytesDoubleSigner []byte
+	)
+
 	responderData := []byte(ulid.New())
 
 	//nolint: paralleltest
@@ -86,13 +91,13 @@ func TestChallengeHappyPath(t *testing.T) {
 		require.NoError(t, err)
 
 		// generate response
-		outerResponsePngBytesDoubleSigner, err = challengeOuterBox.RespondPng(responderPrivateSigningKey, responderPrivateSigningKey2, responderData)
+		challengeResponsePngBytesDoubleSigner, err = challengeOuterBox.RespondPng(responderPrivateSigningKey, responderPrivateSigningKey2, responderData)
 		require.NoError(t, err)
 	})
 
 	//nolint: paralleltest
 	t.Run("challenger handles response", func(t *testing.T) {
-		for _, responsePngBytes := range [][]byte{challengeResponsePngBytesSingleSigner, outerResponsePngBytesDoubleSigner} {
+		for _, responsePngBytes := range [][]byte{challengeResponsePngBytesSingleSigner, challengeResponsePngBytesDoubleSigner} {
 			outerResponse, err := UnmarshalResponsePng(responsePngBytes)
 			require.NoError(t, err)
 

--- a/pkg/challenge/challenge_test.go
+++ b/pkg/challenge/challenge_test.go
@@ -192,7 +192,7 @@ func TestSignWithTimeout(t *testing.T) {
 			signerFunc: func() crypto.Signer {
 				return timeoutSigner{}
 			},
-			errString: "signing timed out after 4 attempts, last error: signing data: TEST ERROR",
+			errString: "signing timed out",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/challenge/response.go
+++ b/pkg/challenge/response.go
@@ -38,6 +38,9 @@ func (o *OuterResponse) Open(privateEncryptionKey [32]byte) (*InnerResponse, err
 
 	// no sig 2 provided, return what we have
 	if o.Sig2 == nil || len(o.Sig2) <= 0 {
+		// if there is no sig2, set public signing key 2 to nil just in case so that
+		// the consumer does not fasly assume it was used to perform a signature
+		innerResponse.PublicSigningKey2 = nil
 		return &innerResponse, nil
 	}
 

--- a/pkg/challenge/response.go
+++ b/pkg/challenge/response.go
@@ -34,17 +34,12 @@ func (o *OuterResponse) Open(privateEncryptionKey [32]byte) (*InnerResponse, err
 		return nil, fmt.Errorf("verifying challenge signature: %w", err)
 	}
 
-	// neither signature 2 nor public signing key 2 was provided, return what we have
-	if (o.Sig2 == nil || len(o.Sig2) <= 0) && (innerResponse.PublicSigningKey2 == nil || len(innerResponse.PublicSigningKey2) <= 0) {
+	// no sig 2 provided, return what we have
+	if o.Sig2 == nil || len(o.Sig2) <= 0 {
 		return &innerResponse, nil
 	}
 
-	// public key 2, no signature 2
-	if o.Sig2 == nil || len(o.Sig2) <= 0 {
-		return nil, fmt.Errorf("have public siging key 2 but no signature 2")
-	}
-
-	// signature 2, no public key 2
+	// got a signature 2, no public key 2
 	if innerResponse.PublicSigningKey2 == nil || len(innerResponse.PublicSigningKey2) <= 0 {
 		return nil, fmt.Errorf("have signature 2 but no public signing key 2")
 	}

--- a/pkg/echelper/helpers.go
+++ b/pkg/echelper/helpers.go
@@ -70,19 +70,13 @@ func OpenNaCl(sealed []byte, counterPartyPublicKey, privateKey *[32]byte) ([]byt
 	return opened, nil
 }
 
-func PublicEcdsaKeyToPem(pub *ecdsa.PublicKey) ([]byte, error) {
-	bytes, err := x509.MarshalPKIXPublicKey(pub)
-	if err != nil {
-		return nil, err
-	}
-
-	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: bytes}), nil
-}
-
 func PublicPemToEcdsaKey(keyBytes []byte) (*ecdsa.PublicKey, error) {
 	block, _ := pem.Decode(keyBytes)
+	return PublicDerToEcdsaKey(block.Bytes)
+}
 
-	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+func PublicDerToEcdsaKey(der []byte) (*ecdsa.PublicKey, error) {
+	key, err := x509.ParsePKIXPublicKey(der)
 	if err != nil {
 		return nil, fmt.Errorf("parsing pkix public key: %w", err)
 	}

--- a/pkg/echelper/helpers.go
+++ b/pkg/echelper/helpers.go
@@ -7,10 +7,12 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	"golang.org/x/crypto/nacl/box"
 )
@@ -75,6 +77,14 @@ func PublicPemToEcdsaKey(keyBytes []byte) (*ecdsa.PublicKey, error) {
 	return PublicDerToEcdsaKey(block.Bytes)
 }
 
+func PublicB64DerToEcdsaKey(keyBytes []byte) (*ecdsa.PublicKey, error) {
+	decoded, err := base64.StdEncoding.DecodeString(string(keyBytes))
+	if err != nil {
+		return nil, err
+	}
+	return PublicDerToEcdsaKey(decoded)
+}
+
 func PublicDerToEcdsaKey(der []byte) (*ecdsa.PublicKey, error) {
 	key, err := x509.ParsePKIXPublicKey(der)
 	if err != nil {
@@ -88,8 +98,39 @@ func PublicDerToEcdsaKey(der []byte) (*ecdsa.PublicKey, error) {
 	return pub, nil
 }
 
+func PublicEcdsaToB64Der(key *ecdsa.PublicKey) ([]byte, error) {
+	der, err := x509.MarshalPKIXPublicKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(base64.StdEncoding.EncodeToString(der)), nil
+}
+
 func GenerateEcdsaKey() (*ecdsa.PrivateKey, error) {
 	return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+}
+
+func SignWithTimeout(signer crypto.Signer, data []byte, duration, interval time.Duration) ([]byte, error) {
+	timeout := time.NewTimer(duration)
+	intervalTicker := time.NewTicker(interval)
+	attempts := 0
+
+	for {
+		signature, err := Sign(signer, data)
+		if err == nil {
+			return signature, nil
+		}
+
+		attempts++
+
+		select {
+		case <-timeout.C:
+			return nil, fmt.Errorf("signing timed out after %d attempts, last error: %w", attempts, err)
+		case <-intervalTicker.C:
+			continue
+		}
+	}
 }
 
 func hashForSignature(data []byte) ([]byte, error) {

--- a/test/krypto/challenge_test.rb
+++ b/test/krypto/challenge_test.rb
@@ -37,20 +37,20 @@ class TestKryptoChallenge < Minitest::Test
   end
 
   def validate_response(private_encryption_key, response)
-        # The challenger uses the challengeId to find the ephemeral encrytion key, and opens the response.
-        assert_equal(CHALLENGE_ID, response.challengeId)
+    # The challenger uses the challengeId to find the ephemeral encrytion key, and opens the response.
+    assert_equal(CHALLENGE_ID, response.challengeId)
 
-        # The challenger uses the challengeId to find the ephemeral encrytion key, and opens the response.
-        assert_equal(CHALLENGE_ID, response.challengeId)
+    # The challenger uses the challengeId to find the ephemeral encrytion key, and opens the response.
+    assert_equal(CHALLENGE_ID, response.challengeId)
 
-        opened = response.open(private_encryption_key)
-        refute_nil(opened)
+    opened = response.open(private_encryption_key)
+    refute_nil(opened)
 
-        # We've passed the encryption, does the challenge data match what we expect?
-        # (in real usage, this would be a rails authenticator)
-        assert_equal(CHALLENGE_DATA, opened.challengeData)
+    # We've passed the encryption, does the challenge data match what we expect?
+    # (in real usage, this would be a rails authenticator)
+    assert_equal(CHALLENGE_DATA, opened.challengeData)
 
-        # And finally, the challenger does something with the results.
-        assert_equal(RESPONDER_DATA, opened.responseData)
+    # And finally, the challenger does something with the results.
+    assert_equal(RESPONDER_DATA, opened.responseData)
   end
 end


### PR DESCRIPTION
- adds second signer option for challenges
- appeasing linter
- adds comments around using nil signer 2 key to craft response
- only checks for sig2 key when sig2 present
- uses b64 der key format, only checks for presense of sig2 before verifying
- linter appeasment
- ensures signing key 2 is set to nil if sig2 is not present
- adds timeout to signing ops
- tweaks sign with timeout test
- adds a few more tests
- consistent var naming and declaration in tests
- code clean up in response to PR feed back
- testing disabling simulator internal pkg
