### PR TITLE
updates ruby side of challenge to allow setting of timestamp

### DIFF
--- a/cross_language_tests/challenge.rb
+++ b/cross_language_tests/challenge.rb
@@ -20,7 +20,7 @@ case cmd
 when "generate"
   # write the private encryption key to the test directory to retrieve in later tests
   key = OpenSSL::PKey::EC.new(test_case["RubyPrivateSigningKey"])
-  result = Krypto::Challenge.generate(key, test_case["ChallengeId"], test_case["ChallengeData"], test_case["RequestData"], Time.now.to_i)
+  result = Krypto::Challenge.generate(key, test_case["ChallengeId"], test_case["ChallengeData"], test_case["RequestData"], Time.now)
   File.write(private_encryption_key_path, Base64.strict_encode64(result[1]))
 
   # return the challenge

--- a/cross_language_tests/challenge.rb
+++ b/cross_language_tests/challenge.rb
@@ -20,7 +20,7 @@ case cmd
 when "generate"
   # write the private encryption key to the test directory to retrieve in later tests
   key = OpenSSL::PKey::EC.new(test_case["RubyPrivateSigningKey"])
-  result = Krypto::Challenge.generate(key, test_case["ChallengeId"], test_case["ChallengeData"], test_case["RequestData"], Time.now)
+  result = Krypto::Challenge.generate(key, test_case["ChallengeId"], test_case["ChallengeData"], test_case["RequestData"], timestamp: Time.now)
   File.write(private_encryption_key_path, Base64.strict_encode64(result[1]))
 
   # return the challenge

--- a/cross_language_tests/challenge.rb
+++ b/cross_language_tests/challenge.rb
@@ -20,7 +20,7 @@ case cmd
 when "generate"
   # write the private encryption key to the test directory to retrieve in later tests
   key = OpenSSL::PKey::EC.new(test_case["RubyPrivateSigningKey"])
-  result = Krypto::Challenge.generate(key, test_case["ChallengeId"], test_case["ChallengeData"], test_case["RequestData"])
+  result = Krypto::Challenge.generate(key, test_case["ChallengeId"], test_case["ChallengeData"], test_case["RequestData"], Time.now.to_i)
   File.write(private_encryption_key_path, Base64.strict_encode64(result[1]))
 
   # return the challenge

--- a/lib/krypto/challenge.rb
+++ b/lib/krypto/challenge.rb
@@ -6,7 +6,7 @@ require "openssl"
 
 module Krypto
   class Challenge
-    def self.generate(signing_key, challenge_id, challenge_data, request_data, unix_timestamp)
+    def self.generate(signing_key, challenge_id, challenge_data, request_data, timestamp: Time.now)
       private_encryption_key = RbNaCl::PrivateKey.generate
       public_encryption_key = private_encryption_key.public_key
 
@@ -15,7 +15,7 @@ module Krypto
           publicEncryptionKey: public_encryption_key.to_bytes,
           challengeData: challenge_data,
           requestData: request_data,
-          timestamp: unix_timestamp,
+          timestamp: timestamp.to_i,
           challengeId: challenge_id
         )
       )

--- a/lib/krypto/challenge.rb
+++ b/lib/krypto/challenge.rb
@@ -6,7 +6,7 @@ require "openssl"
 
 module Krypto
   class Challenge
-    def self.generate(signing_key, challenge_id, challenge_data, request_data)
+    def self.generate(signing_key, challenge_id, challenge_data, request_data, unix_timestamp)
       private_encryption_key = RbNaCl::PrivateKey.generate
       public_encryption_key = private_encryption_key.public_key
 
@@ -15,7 +15,7 @@ module Krypto
           publicEncryptionKey: public_encryption_key.to_bytes,
           challengeData: challenge_data,
           requestData: request_data,
-          timestamp: Time.now.to_i,
+          timestamp: unix_timestamp,
           challengeId: challenge_id
         )
       )

--- a/test/krypto/challenge_test.rb
+++ b/test/krypto/challenge_test.rb
@@ -22,7 +22,7 @@ class TestKryptoChallenge < Minitest::Test
 
   def test_challenge
     # First, the challenger generates a challenge, and stashes the private key somewhere for future retrivial
-    challenge, private_encryption_key = ::Krypto::Challenge.generate(CHALLENGER_KEY, CHALLENGE_ID, CHALLENGE_DATA, REQUEST_DATA, Time.now.to_i)
+    challenge, private_encryption_key = ::Krypto::Challenge.generate(CHALLENGER_KEY, CHALLENGE_ID, CHALLENGE_DATA, REQUEST_DATA)
 
     # Next, the responder, having recieved the challenge, verifies it, and examines it.
     assert(challenge.verify(CHALLENGER_PUB))

--- a/test/krypto/challenge_test.rb
+++ b/test/krypto/challenge_test.rb
@@ -22,7 +22,7 @@ class TestKryptoChallenge < Minitest::Test
 
   def test_challenge
     # First, the challenger generates a challenge, and stashes the private key somewhere for future retrivial
-    challenge, private_encryption_key = ::Krypto::Challenge.generate(CHALLENGER_KEY, CHALLENGE_ID, CHALLENGE_DATA, REQUEST_DATA)
+    challenge, private_encryption_key = ::Krypto::Challenge.generate(CHALLENGER_KEY, CHALLENGE_ID, CHALLENGE_DATA, REQUEST_DATA, Time.now.to_i)
 
     # Next, the responder, having recieved the challenge, verifies it, and examines it.
     assert(challenge.verify(CHALLENGER_PUB))


### PR DESCRIPTION
closes https://github.com/kolide/launcher/issues/1160 

relates to https://github.com/kolide/launcher/pull/1161

updates kryto ruby library so that time stamp can be passed to nacl box
see: https://github.com/kolide/launcher/issues/1160

@directionless , @blaedj / @pelted I think this will give us enough rope server side to update the timestamp in the krypto box. I guess k2 would have to try once, it it gets a 401, try again, but set responses locatime header as the timestamp in the krypto box.