### PR TITLE
Make 'timestamp' a positional argument

### DIFF
--- a/lib/krypto/challenge.rb
+++ b/lib/krypto/challenge.rb
@@ -6,7 +6,7 @@ require "openssl"
 
 module Krypto
   class Challenge
-    def self.generate(signing_key, challenge_id, challenge_data, request_data, timestamp: Time.now)
+    def self.generate(signing_key, challenge_id, challenge_data, request_data, timestamp = Time.now)
       private_encryption_key = RbNaCl::PrivateKey.generate
       public_encryption_key = private_encryption_key.public_key
 


### PR DESCRIPTION
`#generate()` uses positional arguments for everything but the last `timestamp` keyword argument. This change is more for consistency. 

Mixing positional and keyword arguments is normal. This method already has 4 existing positional arguments in front of this one which forces callers to reason more about how to use this method when the last argument is suddenly a keyword. [^1]

[^1]: Another, arguably more expandable, approach would be a `**options` splat and pass `timestamp` in  a hash.