### PR TITLE
use secure enclave public key, tweaks

### DIFF
--- a/pkg/challenge/challenge.go
+++ b/pkg/challenge/challenge.go
@@ -26,7 +26,7 @@ type OuterChallenge struct {
 }
 
 func (o *OuterChallenge) Verify(counterParty ecdsa.PublicKey) error {
-	if err := echelper.VerifySignature(counterParty, o.Msg, o.Sig); err != nil {
+	if err := echelper.VerifySignature(&counterParty, o.Msg, o.Sig); err != nil {
 		return err
 	}
 

--- a/pkg/challenge/response.go
+++ b/pkg/challenge/response.go
@@ -72,7 +72,7 @@ func verifyWithKeyBytes(keyBytes []byte, msg []byte, sig []byte) error {
 		return fmt.Errorf("parsing public key: %w", err)
 	}
 
-	return echelper.VerifySignature(*key, msg, sig)
+	return echelper.VerifySignature(key, msg, sig)
 }
 
 type InnerResponse struct {

--- a/pkg/echelper/helpers.go
+++ b/pkg/echelper/helpers.go
@@ -18,7 +18,7 @@ import (
 )
 
 func Sign(signer crypto.Signer, data []byte) ([]byte, error) {
-	digest, err := hashForSignature(data)
+	digest, err := HashForSignature(data)
 	if err != nil {
 		return nil, fmt.Errorf("hashing data: %w", err)
 	}
@@ -31,13 +31,13 @@ func Sign(signer crypto.Signer, data []byte) ([]byte, error) {
 	return signature, nil
 }
 
-func VerifySignature(counterParty ecdsa.PublicKey, data []byte, signature []byte) error {
-	digest, err := hashForSignature(data)
+func VerifySignature(counterParty *ecdsa.PublicKey, data []byte, signature []byte) error {
+	digest, err := HashForSignature(data)
 	if err != nil {
 		return fmt.Errorf("hashing inner box: %w", err)
 	}
 
-	if !ecdsa.VerifyASN1(&counterParty, digest, signature) {
+	if !ecdsa.VerifyASN1(counterParty, digest, signature) {
 		return fmt.Errorf("invalid signature")
 	}
 
@@ -135,7 +135,7 @@ func SignWithTimeout(signer crypto.Signer, data []byte, duration, interval time.
 	}
 }
 
-func hashForSignature(data []byte) ([]byte, error) {
+func HashForSignature(data []byte) ([]byte, error) {
 	hash := sha256.New()
 	_, err := hash.Write(data)
 	if err != nil {

--- a/pkg/secureenclave/secureenclave.go
+++ b/pkg/secureenclave/secureenclave.go
@@ -81,7 +81,7 @@ func (s *SecureEnclaveSigner) Sign(rand io.Reader, digest []byte, opts crypto.Si
 	return result, nil
 }
 
-// CreateKey creates a new secure enclave key and returns the hash used to access it.
+// CreateKey creates a new secure enclave key and returns the public key.
 func CreateKey() (*ecdsa.PublicKey, error) {
 	wrapper := C.wrapCreateKey()
 	result, err := unwrap(wrapper)

--- a/pkg/secureenclave/secureenclave_test.go
+++ b/pkg/secureenclave/secureenclave_test.go
@@ -95,7 +95,7 @@ func TestSecureEnclaveSigning(t *testing.T) {
 
 	publicKey := seSigner.Public().(*ecdsa.PublicKey)
 
-	require.NoError(t, echelper.VerifySignature(*publicKey, dataToSign, signature))
+	require.NoError(t, echelper.VerifySignature(publicKey, dataToSign, signature))
 }
 
 func TestSecureEnclaveErrors(t *testing.T) {

--- a/pkg/tpm/tpm_test.go
+++ b/pkg/tpm/tpm_test.go
@@ -35,7 +35,7 @@ func TestTpmSigning(t *testing.T) {
 
 	publicKey := tpmSigner.Public().(*ecdsa.PublicKey)
 
-	require.NoError(t, echelper.VerifySignature(*publicKey, dataToSign, signature))
+	require.NoError(t, echelper.VerifySignature(publicKey, dataToSign, signature))
 }
 
 func TestTpmErrors(t *testing.T) {


### PR DESCRIPTION
updates secure enclave code to return public key instead of hash

releates to https://github.com/kolide/launcher/pull/1514