### PR TITLE
enable tpm tests on windows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - name: install actionlint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,8 +99,8 @@ jobs:
       if: runner.os == 'Windows'
       shell: bash
       run: |
-        echo "CGO_CFLAGS=-IC:\msys64\ucrt64\include" >> "$GITHUB_ENV"
-        echo "CGO_LDFLAGS=-LC:\msys64\ucrt64\lib" >> "$GITHUB_ENV"
+        echo "CGO_CFLAGS=-IC:\mingw64\opt\include" >> "$GITHUB_ENV"
+        echo "CGO_LDFLAGS=-LC:\mingw64\opt\lib" >> "$GITHUB_ENV"s
     - name: Install Libsodium on Windows
       if: runner.os == 'Windows'
       # this is a dependency of the ruby rbnacl library

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,8 +62,8 @@ jobs:
       if: runner.os == 'Windows'
       shell: bash
       run: |
-        echo "CGO_CFLAGS=-IC:\msys64\ucrt64\include" >> "$GITHUB_ENV"
-        echo "CGO_LDFLAGS=-LC:\msys64\ucrt64\lib" >> "$GITHUB_ENV"
+        echo "CGO_CFLAGS=-IC:\mingw64\opt\include" >> "$GITHUB_ENV"
+        echo "CGO_LDFLAGS=-LC:\mingw64\opt\lib" >> "$GITHUB_ENV"
     - name: set macos cgo flags
       if: runner.os == 'macos'
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3
     - name: set windows cgo flags
       if: runner.os == 'Windows'
+      shell: bash
       run: |
         echo "CGO_CFLAGS=-IC:\Progra~1\OpenSSL-Win64\include" >> "$GITHUB_ENV"
         echo "CGO_LDFLAGS=-LC:\Progra~1\OpenSSL-Win64\lib" >> "$GITHUB_ENV"
@@ -96,6 +97,7 @@ jobs:
         bundler-cache: true
     - name: set windows cgo flags
       if: runner.os == 'Windows'
+      shell: bash
       run: |
         echo "CGO_CFLAGS=-IC:\Progra~1\OpenSSL-Win64\include" >> "$GITHUB_ENV"
         echo "CGO_LDFLAGS=-LC:\Progra~1\OpenSSL-Win64\lib" >> "$GITHUB_ENV"s

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       if: runner.os == 'Windows'
       shell: bash
       run: |
-        echo "CGO_CFLAGS=-IC:\msys64\ucrt64\include\openssl" >> "$GITHUB_ENV"
+        echo "CGO_CFLAGS=-IC:\msys64\ucrt64\include" >> "$GITHUB_ENV"
     - name: set macos cgo flags
       if: runner.os == 'macos'
       run: |
@@ -98,7 +98,7 @@ jobs:
       if: runner.os == 'Windows'
       shell: bash
       run: |
-        echo "CGO_CFLAGS=-IC:\msys64\ucrt64\include\openssl" >> "$GITHUB_ENV"
+        echo "CGO_CFLAGS=-IC:\msys64\ucrt64\include" >> "$GITHUB_ENV"
     - name: Install Libsodium on Windows
       if: runner.os == 'Windows'
       # this is a dependency of the ruby rbnacl library

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,14 +56,13 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
         cache: true
-    - name: Install OpenSSL on Windows
-      if: runner.os == 'Windows'
-      # this is required to be able to run the TPM simulator on Windows
-      # https://github.com/google/go-tpm-tools#openssl-errors-when-building-simulator
-      run: choco install openssl --version=3.3.1
-      shell: bash
     - name: Lint
       uses: golangci/golangci-lint-action@v3
+    - name: set windows cgo flags
+      if: runner.os == 'Windows'
+      run: |
+        echo CGO_CFLAGS="-IC:\Program Files\OpenSSL-Win64\include" >> "$GITHUB_ENV"
+        echo CGO_LDFLAGS="-LC:\Program Files\OpenSSL-Win64\lib" >> "$GITHUB_ENV"
     - name: set macos cgo flags
       if: runner.os == 'macos'
       run: |
@@ -95,12 +94,11 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: Install OpenSSL on Windows
+    - name: set windows cgo flags
       if: runner.os == 'Windows'
-      # this is required to be able to run the TPM simulator on Windows
-      # https://github.com/google/go-tpm-tools#openssl-errors-when-building-simulator
-      run: choco install openssl --version=3.3.1
-      shell: bash
+      run: |
+        echo CGO_CFLAGS="-IC:\Program Files\OpenSSL-Win64\include" >> "$GITHUB_ENV"
+        echo CGO_LDFLAGS="-LC:\Program Files\OpenSSL-Win64\lib" >> "$GITHUB_ENV"
     - name: Install Libsodium on Windows
       if: runner.os == 'Windows'
       # this is a dependency of the ruby rbnacl library

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,12 +56,6 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
         cache: true
-    - name: Install OpenSSL on Windows
-      if: runner.os == 'Windows'
-      # this is required to be able to run the TPM simulator on Windows
-      # https://github.com/google/go-tpm-tools#openssl-errors-when-building-simulator
-      run: choco install openssl
-      shell: bash
     - name: Lint
       uses: golangci/golangci-lint-action@v3
     - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,8 +61,8 @@ jobs:
     - name: set windows cgo flags
       if: runner.os == 'Windows'
       run: |
-        echo CGO_CFLAGS="-IC:\Program Files\OpenSSL-Win64\include" >> "$GITHUB_ENV"
-        echo CGO_LDFLAGS="-LC:\Program Files\OpenSSL-Win64\lib" >> "$GITHUB_ENV"
+        echo "CGO_CFLAGS=-IC:\Progra~1\OpenSSL-Win64\include" >> "$GITHUB_ENV"
+        echo "CGO_LDFLAGS=-LC:\Progra~1\OpenSSL-Win64\lib" >> "$GITHUB_ENV"
     - name: set macos cgo flags
       if: runner.os == 'macos'
       run: |
@@ -97,8 +97,8 @@ jobs:
     - name: set windows cgo flags
       if: runner.os == 'Windows'
       run: |
-        echo CGO_CFLAGS="-IC:\Program Files\OpenSSL-Win64\include" >> "$GITHUB_ENV"
-        echo CGO_LDFLAGS="-LC:\Program Files\OpenSSL-Win64\lib" >> "$GITHUB_ENV"
+        echo "CGO_CFLAGS=-IC:\Progra~1\OpenSSL-Win64\include" >> "$GITHUB_ENV"
+        echo "CGO_LDFLAGS=-LC:\Progra~1\OpenSSL-Win64\lib" >> "$GITHUB_ENV"s
     - name: Install Libsodium on Windows
       if: runner.os == 'Windows'
       # this is a dependency of the ruby rbnacl library

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,10 @@ jobs:
       # https://github.com/google/go-tpm-tools#openssl-errors-when-building-simulator
       run: choco install openssl
       shell: bash
+    - name: Install OpenSSL on Macos
+      if: runner.os == 'macOS'
+      run: |
+        brew install openssl
     - name: Lint
       uses: golangci/golangci-lint-action@v3
     - name: Test
@@ -99,10 +103,6 @@ jobs:
       # https://github.com/google/go-tpm-tools#openssl-errors-when-building-simulator
       run: choco install openssl
       shell: bash
-    - name: Install Mac packages
-      if: runner.os == 'macOS'
-      run: |
-        brew install openssl
     - name: Install Libsodium on Windows
       if: runner.os == 'Windows'
       # this is a dependency of the ruby rbnacl library

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,10 +62,6 @@ jobs:
       # https://github.com/google/go-tpm-tools#openssl-errors-when-building-simulator
       run: choco install openssl
       shell: bash
-    - name: Install OpenSSL on Macos
-      if: runner.os == 'macOS'
-      run: |
-        brew install openssl
     - name: Lint
       uses: golangci/golangci-lint-action@v3
     - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
       shell: bash
       run: |
         echo "CGO_CFLAGS=-IC:\msys64\ucrt64\include" >> "$GITHUB_ENV"
+        echo "CGO_LDFLAGS=-LC:\msys64\ucrt64\lib" >> "$GITHUB_ENV"
     - name: set macos cgo flags
       if: runner.os == 'macos'
       run: |
@@ -99,6 +100,7 @@ jobs:
       shell: bash
       run: |
         echo "CGO_CFLAGS=-IC:\msys64\ucrt64\include" >> "$GITHUB_ENV"
+        echo "CGO_LDFLAGS=-LC:\msys64\ucrt64\lib" >> "$GITHUB_ENV"
     - name: Install Libsodium on Windows
       if: runner.os == 'Windows'
       # this is a dependency of the ruby rbnacl library

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,10 @@ jobs:
       # https://github.com/google/go-tpm-tools#openssl-errors-when-building-simulator
       run: choco install openssl
       shell: bash
+    - name: Install Mac packages
+      if: runner.os == 'macOS'
+      run: |
+        brew install openssl
     - name: Install Libsodium on Windows
       if: runner.os == 'Windows'
       # this is a dependency of the ruby rbnacl library

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,8 +56,6 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
         cache: true
-    - name: Lint
-      uses: golangci/golangci-lint-action@v3
     - name: set windows cgo flags
       if: runner.os == 'Windows'
       shell: bash
@@ -69,6 +67,8 @@ jobs:
       run: |
         echo CGO_CFLAGS="-I$(brew --prefix openssl)/include" >> "$GITHUB_ENV"
         echo CGO_LDFLAGS="-L$(brew --prefix openssl)/lib" >> "$GITHUB_ENV"
+    - name: Lint
+      uses: golangci/golangci-lint-action@v3
     - name: Test
       run: go test -tags skiplint $(go list ./... | grep -v cross_language_tests) -race -cover
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,8 +70,8 @@ jobs:
     - name: set macos cgo flags
       if: runner.os == 'macos'
       run: |
-        export CGO_CFLAGS="-I$(brew --prefix openssl)/include"
-        export CGO_LDFLAGS="-L$(brew --prefix openssl)/lib"
+        echo CGO_CFLAGS="-I$(brew --prefix openssl)/include" >> $GITHUB_ENV
+        echo CGO_LDFLAGS="-L$(brew --prefix openssl)/lib" >> $GITHUB_ENV
     - name: Test
       run: go test -tags skiplint $(go list ./... | grep -v cross_language_tests) -race -cover
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
       if: runner.os == 'Windows'
       # this is required to be able to run the TPM simulator on Windows
       # https://github.com/google/go-tpm-tools#openssl-errors-when-building-simulator
-      run: choco install openssl -y
+      run: choco install openssl --version=3.3.1 -y
       shell: bash
     - name: Lint
       uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,8 +62,7 @@ jobs:
       if: runner.os == 'Windows'
       shell: bash
       run: |
-        echo "CGO_CFLAGS=-IC:\Progra~1\OpenSSL-Win64\include" >> "$GITHUB_ENV"
-        echo "CGO_LDFLAGS=-LC:\Progra~1\OpenSSL-Win64\lib" >> "$GITHUB_ENV"
+        echo "CGO_CFLAGS=-IC:\msys64\ucrt64\include\openssl" >> "$GITHUB_ENV"
     - name: set macos cgo flags
       if: runner.os == 'macos'
       run: |
@@ -95,17 +94,11 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: set findopenssl
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: |
-        ls C:\ aes.h -Recurse -ErrorAction silentlycontinue
     - name: set windows cgo flags
       if: runner.os == 'Windows'
       shell: bash
       run: |
-        echo "CGO_CFLAGS=-IC:\Progra~1\OpenSSL-Win64\include" >> "$GITHUB_ENV"
-        echo "CGO_LDFLAGS=-LC:\Progra~1\OpenSSL-Win64\lib" >> "$GITHUB_ENV"s
+        echo "CGO_CFLAGS=-IC:\msys64\ucrt64\include\openssl" >> "$GITHUB_ENV"
     - name: Install Libsodium on Windows
       if: runner.os == 'Windows'
       # this is a dependency of the ruby rbnacl library

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,8 +67,13 @@ jobs:
     - name: Test
       run: go test $(go list ./... | grep -v cross_language_tests) -race
       shell: bash
-    - name: Test skiplint tagged
-      run: CGO_CFLAGS="-I$(brew --prefix openssl)/include" CGO_LDFLAGS="-L$(brew --prefix openssl)/lib" go test -tags skiplint $(go list ./... | grep -v cross_language_tests) -race
+    - name: set macos cgo flags
+      if: runner.os == 'macos'
+      run: |
+        export CGO_CFLAGS="-I$(brew --prefix openssl)/include"
+        export CGO_LDFLAGS="-L$(brew --prefix openssl)/lib"
+    - name: Test
+      run: go test -tags skiplint $(go list ./... | grep -v cross_language_tests) -race -cover
       shell: bash
 
   cross:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v3
     - name: Test
-      run: go test -tags skiplint $(go list ./... | grep -v cross_language_tests) -race -cover
+      run: go test $(go list ./... | grep -v cross_language_tests) -race -cover
       shell: bash
 
   cross:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
       run: go test $(go list ./... | grep -v cross_language_tests) -race
       shell: bash
     - name: Test skiplint tagged
-      run: go test -tags skiplint $(go list ./... | grep -v cross_language_tests) -race
+      run: CGO_CFLAGS="-I$(brew --prefix openssl)/include" CGO_LDFLAGS="-L$(brew --prefix openssl)/lib" go test -tags skiplint $(go list ./... | grep -v cross_language_tests) -race
       shell: bash
 
   cross:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,16 +56,19 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
         cache: true
+    - name: Install OpenSSL on Windows
+      if: runner.os == 'Windows'
+      # this is required to be able to run the TPM simulator on Windows
+      # https://github.com/google/go-tpm-tools#openssl-errors-when-building-simulator
+      run: choco install openssl -y
+      shell: bash
     - name: Lint
       uses: golangci/golangci-lint-action@v3
-    - name: Test
-      run: go test $(go list ./... | grep -v cross_language_tests) -race
-      shell: bash
     - name: set macos cgo flags
       if: runner.os == 'macos'
       run: |
-        echo CGO_CFLAGS="-I$(brew --prefix openssl)/include" >> $GITHUB_ENV
-        echo CGO_LDFLAGS="-L$(brew --prefix openssl)/lib" >> $GITHUB_ENV
+        echo CGO_CFLAGS="-I$(brew --prefix openssl)/include" >> "$GITHUB_ENV"
+        echo CGO_LDFLAGS="-L$(brew --prefix openssl)/lib" >> "$GITHUB_ENV"
     - name: Test
       run: go test -tags skiplint $(go list ./... | grep -v cross_language_tests) -race -cover
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,9 @@ jobs:
     - name: Test
       run: go test $(go list ./... | grep -v cross_language_tests) -race
       shell: bash
+    - name: Test skiplint tagged
+      run: go test -tags skiplint $(go list ./... | grep -v cross_language_tests) -race
+      shell: bash
 
   cross:
     name: Cross - Go ${{ matrix.go }} Ruby ${{ matrix.ruby }} ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,11 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+    - name: set findopenssl
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        ls C:\ aes.h -Recurse -ErrorAction silentlycontinue
     - name: set windows cgo flags
       if: runner.os == 'Windows'
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
       if: runner.os == 'Windows'
       # this is required to be able to run the TPM simulator on Windows
       # https://github.com/google/go-tpm-tools#openssl-errors-when-building-simulator
-      run: choco install openssl --version=3.3.1 -y
+      run: choco install openssl --version=3.3.1
       shell: bash
     - name: Lint
       uses: golangci/golangci-lint-action@v3
@@ -99,7 +99,7 @@ jobs:
       if: runner.os == 'Windows'
       # this is required to be able to run the TPM simulator on Windows
       # https://github.com/google/go-tpm-tools#openssl-errors-when-building-simulator
-      run: choco install openssl
+      run: choco install openssl --version=3.3.1
       shell: bash
     - name: Install Libsodium on Windows
       if: runner.os == 'Windows'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,12 +95,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: set windows cgo flags
-      if: runner.os == 'Windows'
-      shell: bash
-      run: |
-        echo "CGO_CFLAGS=-IC:\mingw64\opt\include" >> "$GITHUB_ENV"
-        echo "CGO_LDFLAGS=-LC:\mingw64\opt\lib" >> "$GITHUB_ENV"s
     - name: Install Libsodium on Windows
       if: runner.os == 'Windows'
       # this is a dependency of the ruby rbnacl library

--- a/pkg/tpm/tpm_test.go
+++ b/pkg/tpm/tpm_test.go
@@ -1,6 +1,3 @@
-//go:build skiplint
-// +build skiplint
-
 package tpm
 
 import (

--- a/pkg/tpm/tpm_test.go
+++ b/pkg/tpm/tpm_test.go
@@ -1,3 +1,6 @@
+//go:build skiplint
+// +build skiplint
+
 package tpm
 
 import (

--- a/pkg/tpm/tpm_test.go
+++ b/pkg/tpm/tpm_test.go
@@ -1,6 +1,3 @@
-//go:build !windows
-// +build !windows
-
 package tpm
 
 import (


### PR DESCRIPTION
sets cgo flags to include needed openssl files before linting and testing so that tpm tests can run on all platforms

closes https://github.com/kolide/launcher/issues/1166