### PR TITLE
add delete key, undo unneeded temp key logic

### DIFF
--- a/pkg/secureenclave/secureenclave.go
+++ b/pkg/secureenclave/secureenclave.go
@@ -92,6 +92,28 @@ func CreateKey() (*ecdsa.PublicKey, error) {
 	return rawToEcdsa(result), nil
 }
 
+func DeleteKey(key *ecdsa.PublicKey) error {
+	lookupHash, err := publicKeyLookUpHash(key)
+	if err != nil {
+		return err
+	}
+
+	cHash := C.CBytes(lookupHash)
+	defer C.free(cHash)
+
+	wrapper := C.wrapDeleteKey(cHash)
+	result, err := unwrap(wrapper)
+	if err != nil {
+		return err
+	}
+
+	if len(result) > 0 {
+		return errors.New("failed to delete key")
+	}
+
+	return nil
+}
+
 // unwrap a Wrapper struct to a Go byte slice
 // Free the underlying bufs so caller won't have to deal with them
 func unwrap(w *C.Wrapper) ([]byte, error) {

--- a/pkg/secureenclave/secureenclave.go
+++ b/pkg/secureenclave/secureenclave.go
@@ -82,10 +82,8 @@ func (s *SecureEnclaveSigner) Sign(rand io.Reader, digest []byte, opts crypto.Si
 }
 
 // CreateKey creates a new secure enclave key and returns the public key.
-// Passing false for isPermenant will create a temporary key and provides
-// a way to tell if the secure enclave is actually available
-func CreateKey(isPermenant bool) (*ecdsa.PublicKey, error) {
-	wrapper := C.wrapCreateKey(C.bool(isPermenant))
+func CreateKey() (*ecdsa.PublicKey, error) {
+	wrapper := C.wrapCreateKey()
 	result, err := unwrap(wrapper)
 	if err != nil {
 		return nil, err

--- a/pkg/secureenclave/secureenclave.h
+++ b/pkg/secureenclave/secureenclave.h
@@ -13,4 +13,5 @@ typedef struct wrapper {
 
 Wrapper *wrapCreateKey();
 Wrapper *wrapFindKey(void *hash);
+Wrapper *wrapDeleteKey(void *hash);
 Wrapper *wrapSign(void *hash, void *data, int dataSize);

--- a/pkg/secureenclave/secureenclave.h
+++ b/pkg/secureenclave/secureenclave.h
@@ -1,5 +1,4 @@
 #include <string.h>
-#include <stdbool.h>
 
 // Wrapper is used to provide a common interface for calling c functions that return go like results of
 // return value and error. The size is the size of the return value buffer.
@@ -12,6 +11,6 @@ typedef struct wrapper {
 	char *error;
 } Wrapper;
 
-Wrapper *wrapCreateKey(bool isPermanent);
+Wrapper *wrapCreateKey();
 Wrapper *wrapFindKey(void *hash);
 Wrapper *wrapSign(void *hash, void *data, int dataSize);

--- a/pkg/secureenclave/secureenclave.m
+++ b/pkg/secureenclave/secureenclave.m
@@ -287,7 +287,7 @@ void deleteKey(unsigned char* hash, char** retErr) {
     attributes = NULL;
 
     if (status != 0) {
-      NSString *msg = [NSString stringWithFormat:@"finding key: status %i", (int)status];
+      NSString *msg = [NSString stringWithFormat:@"deleting key: status %i", (int)status];
       *retErr = CFStringToCString((__bridge CFStringRef)msg);
       CFRelease(msg);
       msg = NULL;

--- a/pkg/secureenclave/secureenclave.m
+++ b/pkg/secureenclave/secureenclave.m
@@ -67,7 +67,7 @@ CFDataRef ExtractPubKey(SecKeyRef pubKey) {
   return res;
 }
 
-size_t createKey(unsigned char** ret, char** retErr, bool isPermanent){
+size_t createKey(unsigned char** ret, char** retErr){
     CFErrorRef error = NULL;
 
     // ignoring the depreciated warning for "kSecAttrAccessibleAlwaysThisDeviceOnly" becuase this is the setting
@@ -95,7 +95,7 @@ size_t createKey(unsigned char** ret, char** retErr, bool isPermanent){
         (id)kSecAttrKeySizeInBits: @256,
         (id)kSecAttrTokenID: (id)kSecAttrTokenIDSecureEnclave,
         (id)kSecPrivateKeyAttrs:
-        @{  (id)kSecAttrIsPermanent: isPermanent ? @YES : @NO,
+        @{  (id)kSecAttrIsPermanent: @YES,
             (id)kSecAttrAccessControl: (id)access,
         },
     };
@@ -262,12 +262,12 @@ size_t sign(unsigned char* hash, unsigned char* data, int dataSize, unsigned cha
     return size;
 }
 
-Wrapper *wrapCreateKey(bool isPermanent) {
+Wrapper *wrapCreateKey() {
 	Wrapper *res = (Wrapper *)malloc(sizeof(Wrapper));
 	if (!res)
 		return NULL;
 	memset(res, 0, sizeof(Wrapper));
-	res->size = createKey(&res->buf, &res->error, isPermanent);
+	res->size = createKey(&res->buf, &res->error);
 	return res;
 }
 

--- a/pkg/secureenclave/secureenclave_test.go
+++ b/pkg/secureenclave/secureenclave_test.go
@@ -82,13 +82,7 @@ func TestSecureEnclaveSigning(t *testing.T) {
 
 	t.Log("\nrunning wrapped tests with codesigned app and entitlements")
 
-	tempKeyLookup, err := CreateKey(false)
-	require.NoError(t, err)
-
-	_, err = New(tempKeyLookup)
-	require.Error(t, err, "should be not be able to create a secure enclave keyer from temp key")
-
-	pubKeyLookup, err := CreateKey(true)
+	pubKeyLookup, err := CreateKey()
 	require.NoError(t, err)
 
 	seSigner, err := New(pubKeyLookup)

--- a/pkg/secureenclave/secureenclave_test.go
+++ b/pkg/secureenclave/secureenclave_test.go
@@ -85,10 +85,8 @@ func TestSecureEnclaveSigning(t *testing.T) {
 	pubKeyLookup, err := CreateKey()
 	require.NoError(t, err)
 
-	// test that delete key works
 	require.NoError(t, DeleteKey(pubKeyLookup), "should be able to delete key")
 
-	// try to delet again, should get error
 	require.Error(t, DeleteKey(pubKeyLookup), "should error when trying to delete key again")
 
 	pubKeyLookup, err = CreateKey()

--- a/pkg/secureenclave/secureenclave_test.go
+++ b/pkg/secureenclave/secureenclave_test.go
@@ -85,6 +85,15 @@ func TestSecureEnclaveSigning(t *testing.T) {
 	pubKeyLookup, err := CreateKey()
 	require.NoError(t, err)
 
+	// test that delete key works
+	require.NoError(t, DeleteKey(pubKeyLookup), "should be able to delete key")
+
+	// try to delet again, should get error
+	require.Error(t, DeleteKey(pubKeyLookup), "should error when trying to delete key again")
+
+	pubKeyLookup, err = CreateKey()
+	require.NoError(t, err)
+
 	seSigner, err := New(pubKeyLookup)
 	require.NoError(t, err, "should be able to create a secure enclave keyer from an existing key")
 


### PR DESCRIPTION
this PR add ability to delete a key from secure enclave so we can create a "permanent" key to make sure secure enclave works and then delete it