### PR TITLE
Check type assertion success for pubkeys to avoid panic

### DIFF
--- a/pkg/challenge/challenge.go
+++ b/pkg/challenge/challenge.go
@@ -68,14 +68,24 @@ func (o *OuterChallenge) Respond(signer crypto.Signer, signer2 crypto.Signer, re
 		return nil, fmt.Errorf("no inner. unverified?")
 	}
 
-	pubSigningDer, err := echelper.PublicEcdsaToB64Der(signer.Public().(*ecdsa.PublicKey))
+	ecdsaPubKey, ok := signer.Public().(*ecdsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("signer pubkey in unexpected format (expected ECDSA, got %T)", signer.Public())
+	}
+
+	pubSigningDer, err := echelper.PublicEcdsaToB64Der(ecdsaPubKey)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling public signing key to der: %w", err)
 	}
 
 	var pubSigningKey2Der []byte
 	if signer2 != nil {
-		pubSigningKey2Der, err = echelper.PublicEcdsaToB64Der(signer2.Public().(*ecdsa.PublicKey))
+		ecdsaPubKey2, ok := signer2.Public().(*ecdsa.PublicKey)
+		if !ok {
+			return nil, fmt.Errorf("signer pubkey 2 in unexpected format (expected ECDSA, got %T)", signer2.Public())
+		}
+
+		pubSigningKey2Der, err = echelper.PublicEcdsaToB64Der(ecdsaPubKey2)
 		if err != nil {
 			return nil, fmt.Errorf("marshalling public signing 2 key to der: %w", err)
 		}

--- a/pkg/tpm/tpm.go
+++ b/pkg/tpm/tpm.go
@@ -200,7 +200,12 @@ func loadSignerHandle(tpm io.ReadWriter, parentHandle tpmutil.Handle, publicBlob
 		return 0, nil, fmt.Errorf("decoding public key: %w", err)
 	}
 
-	return handle, cryptoPub.(*ecdsa.PublicKey), nil
+	ecdsaPubKey, ok := cryptoPub.(*ecdsa.PublicKey)
+	if !ok {
+		return 0, nil, fmt.Errorf("signer pubkey in unexpected format (expected ECDSA, got %T)", cryptoPub)
+	}
+
+	return handle, ecdsaPubKey, nil
 }
 
 func (t *TpmSigner) closeInternalTpm(tpm io.ReadWriteCloser) error {


### PR DESCRIPTION
We generally expect to be working with ECDSA pubkeys. We sometimes perform type assertions to convert the `Signer` `PubKey` interface into an ECDSA pubkey, which can panic if given a different type of pubkey. This PR updates to ensure we check the type assertion was successful, to avoid the panic.