### PR TITLE
ci: pin versions to shas, configure dependabot for actions, bump codeql action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           go-version: 1.24
       - name: install actionlint
-        run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11
       - name: actionlint
         run: |
           echo "::add-matcher::.github/actionlint-matcher.json"

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -11,9 +11,9 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Go 1.x
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: 1.24
       - name: install actionlint

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,15 +27,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4.37.1
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4.37.1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4.37.1
+
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,16 +27,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.1
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4.37.1
+        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.1
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
 
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@v1.319.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
@@ -66,7 +66,7 @@ jobs:
         echo CGO_CFLAGS="-I$(brew --prefix openssl)/include" >> "$GITHUB_ENV"
         echo CGO_LDFLAGS="-L$(brew --prefix openssl)/lib" >> "$GITHUB_ENV"
     - name: Lint
-      uses: golangci/golangci-lint-action@v4
+      uses: golangci/golangci-lint-action@v9.3.0
     - name: Test
       run: go test $(go list ./... | grep -v cross_language_tests) -race -cover
       shell: bash
@@ -87,7 +87,7 @@ jobs:
         go-version-file: go.mod
         cache: true
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@v1.319.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1.319.0
+      uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
@@ -66,7 +66,7 @@ jobs:
         echo CGO_CFLAGS="-I$(brew --prefix openssl)/include" >> "$GITHUB_ENV"
         echo CGO_LDFLAGS="-L$(brew --prefix openssl)/lib" >> "$GITHUB_ENV"
     - name: Lint
-      uses: golangci/golangci-lint-action@v9.3.0
+      uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
     - name: Test
       run: go test $(go list ./... | grep -v cross_language_tests) -race -cover
       shell: bash
@@ -87,7 +87,7 @@ jobs:
         go-version-file: go.mod
         cache: true
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1.319.0
+      uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
       # https://github.com/RubyCrypto/rbnacl/wiki/Installing-libsodium#windows
       run: |
         cd "$env:temp"
-        Invoke-WebRequest "https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable-msvc.zip" -OutFile "./libsodium.zip"
+        Invoke-WebRequest "https://github.com/jedisct1/libsodium/releases/download/1.0.18-RELEASE/libsodium-1.0.18-msvc.zip" -OutFile "./libsodium.zip"
         Expand-Archive ".\libsodium.zip"
         Copy-Item ".\libsodium\libsodium\x64\Release\v142\dynamic\libsodium.dll" -Destination "C:\Windows\System32\sodium.dll"
       shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           - '3.1.2'
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Ruby
       uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
       with:
@@ -48,9 +48,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
         go-version-file: go.mod
         cache: true
@@ -80,9 +80,9 @@ jobs:
           - '3.1.2'
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
         go-version-file: go.mod
         cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,39 +1,44 @@
-run:
-  timeout: 5m
-
+version: "2"
 linters:
   enable:
     - bodyclose
-    - errcheck
-    - gofmt
     - gosec
-    - gosimple
-    - govet
-    - ineffassign
     - misspell
     - nakedret
     - noctx
     - paralleltest
     - sqlclosecheck
-    - staticcheck
     - unconvert
-    - unused
-  disable:
-    - deadcode
-    - structcheck
-    - varcheck
-
-linters-settings:
-  errcheck:
-    ignore: github.com/go-kit/kit/log:Log
-  gofmt:
-    simplify: false
-
-issues:
-  exclude-dirs:
-    - test-cmds
-  exclude-rules:
-    # False positive: https://github.com/kunwardeep/paralleltest/issues/8.
-    - linters:
-      - paralleltest
-      text: "does not use range value in test Run"
+  settings:
+    errcheck:
+      exclude-functions:
+        - github.com/go-kit/kit/log:Log
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - paralleltest
+        text: does not use range value in test Run
+    paths:
+      - test-cmds
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  settings:
+    gofmt:
+      simplify: false
+  exclusions:
+    generated: lax
+    paths:
+      - test-cmds
+      - third_party$
+      - builtin$
+      - examples$

--- a/cross_language_tests/png_cross_test.go
+++ b/cross_language_tests/png_cross_test.go
@@ -45,13 +45,9 @@ func TestPngRuby(t *testing.T) {
 			t.Parallel()
 
 			pngfile := path.Join(dir, ulid.New()+".png")
-
-			t.Run("setup", func(t *testing.T) {
-				var pngBuf bytes.Buffer
-				require.NoError(t, krypto.ToPng(&pngBuf, tt.in))
-
-				require.NoError(t, os.WriteFile(pngfile, pngBuf.Bytes(), 0600))
-			})
+			var pngBuf bytes.Buffer
+			require.NoError(t, krypto.ToPng(&pngBuf, tt.in))
+			require.NoError(t, os.WriteFile(pngfile, pngBuf.Bytes(), 0600))
 
 			for _, routine := range []string{"decode-file", "decode-blob", "decode-io"} {
 				routine := routine

--- a/pkg/secureenclave/secureenclave_test.go
+++ b/pkg/secureenclave/secureenclave_test.go
@@ -121,8 +121,7 @@ func TestSecureEnclaveErrors(t *testing.T) {
 func copyFile(t *testing.T, source, destination string) {
 	bytes, err := os.ReadFile(source)
 	require.NoError(t, err)
-	// #nosec G306 -- Need readable files
-	require.NoError(t, os.WriteFile(destination, bytes, 0700))
+	require.NoError(t, os.WriteFile(destination, bytes, 0700)) //nolint:gosec
 }
 
 func signApp(t *testing.T, appRootDir string) {
@@ -132,8 +131,7 @@ func signApp(t *testing.T, appRootDir string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	// #nosec G204 -- This triggers due to using env var in cmd, making exception for test
-	cmd := exec.CommandContext(
+	cmd := exec.CommandContext( //nolint:gosec
 		ctx,
 		"codesign",
 		"--deep",


### PR DESCRIPTION
[KOL-786](https://1password.atlassian.net/browse/KOL-786)

GitHub hardening docs [recommend pinning third party actions](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions). I've done the same for our lone go install.

Changes:
  - Lock down actionlint to a slightly older release.
    - The latest requires Go 1.26 which deprecates multiple secureenclave APIs.
  - Lock third party actions to specific shas.
  - Bump codeql-actions, they were on v3 and depreacted.
  - Configure dependabot for GitHub actions.
  - Bump first party github actions to latest to reduce dependabot PRs.
    - I've reviewed these versions elsewhere.
  - Fix a broken libsodium link for Windows.

Let me know if we should pull anyone else in for the gem portion.