### PR TITLE
secureenclave: remove deprecated crypto APIs, bump to go 1.26.5

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v7
         with:
-          go-version: 1.24
+          go-version-file: go.mod
       - name: install actionlint
         run: go install github.com/rhysd/actionlint/cmd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11
       - name: actionlint

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ This project has a variety of languages all stored in a big pile.
 
 Enjoy!
 
+## Setup
+### MacOS
+To run tests or lint on MacOS, you will need Go, brew, and `openssl@v3`:
+
+```shell
+brew install openssl@3
+export CGO_CFLAGS="-I$(brew --prefix openssl)/include"
+export CGO_LDFLAGS="-L$(brew --prefix openssl)/lib"
+```
+
+Additional steps are required to successfully run the secure enclave tests, [see documentation here](./pkg/secureenclave/test_app_resources/readme.md).
+
 ## FAQ
 
 ### 1. But Why?
@@ -36,7 +48,7 @@ this. (They are go tests, and can be run as `go test
 ## Thanks and References
 
 This wouldn't be possible without the work of various people. As code,
-blog posts, and stackoverflow posts. 
+blog posts, and stackoverflow posts.
 
 * Huge thanks to the go crypto maintainers
 * https://stelfox.net/blog/2014/calculating-rsa-key-fingerprints-in-ruby/ is a short reference about various bits of fingering printing in ruby

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kolide/krypto
 
-go 1.25.0
+go 1.26.5
 
 require (
 	github.com/kolide/kit v0.0.0-20221107170827-fb85e3d59eab

--- a/pkg/secureenclave/publickey_test.go
+++ b/pkg/secureenclave/publickey_test.go
@@ -1,0 +1,43 @@
+//go:build darwin
+// +build darwin
+
+// These tests check against the historical, deprecated crypto APIs.
+package secureenclave
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A key valid with the prior parsing API to confirm the new one works too.
+const (
+	workingRawHex  = "04663bf75236351ee6f6223c4fd4f95174f06e7423c58fcd2f9f64068538a93aeb44e70f697668f352f6aba95f4c5a92141b7153d1bf984f7f25b64363e302f04a"
+	workingSha1Hex = "f83f03e13fed812ee5072bf3148ca6a1a28267fa"
+)
+
+// Key that previously worked with the prior system.
+func TestPublicKeyKnownGood(t *testing.T) {
+	t.Parallel()
+
+	raw, err := hex.DecodeString(workingRawHex)
+	require.NoError(t, err)
+
+	key, err := rawToEcdsa(raw)
+	require.NoError(t, err)
+
+	hash, err := publicKeyLookUpHash(key)
+	require.NoError(t, err)
+	require.Equal(t, workingSha1Hex, hex.EncodeToString(hash))
+}
+
+// Unguarded implementation from crypto/ecdsa panics.
+func TestPublicKeyLookUpHashNilCoordinates(t *testing.T) {
+	t.Parallel()
+
+	_, err := publicKeyLookUpHash(&ecdsa.PublicKey{Curve: elliptic.P256()})
+	require.Error(t, err)
+}

--- a/pkg/secureenclave/secureenclave.go
+++ b/pkg/secureenclave/secureenclave.go
@@ -89,7 +89,7 @@ func CreateKey() (*ecdsa.PublicKey, error) {
 		return nil, err
 	}
 
-	return rawToEcdsa(result), nil
+	return rawToEcdsa(result)
 }
 
 func DeleteKey(key *ecdsa.PublicKey) error {
@@ -149,28 +149,26 @@ func findKey(publicKeySha1 []byte) (*ecdsa.PublicKey, error) {
 		return nil, err
 	}
 
-	return rawToEcdsa(result), nil
+	return rawToEcdsa(result)
 }
 
-func rawToEcdsa(raw []byte) *ecdsa.PublicKey {
-	ecKey := new(ecdsa.PublicKey)
-	ecKey.Curve = elliptic.P256()
-	// lint here suggestest using ecdh package, but we are using ecdsa key through out the code
-	// have found a straight forward to go from ecdh.P256().NewPublicKey(raw) -> ecdsa.PublicKey
-	//nolint:staticcheck
-	ecKey.X, ecKey.Y = elliptic.Unmarshal(ecKey.Curve, raw)
-	return ecKey
+func rawToEcdsa(raw []byte) (*ecdsa.PublicKey, error) {
+	return ecdsa.ParseUncompressedPublicKey(elliptic.P256(), raw)
 }
 
 func publicKeyLookUpHash(key *ecdsa.PublicKey) ([]byte, error) {
+	// PublicKey.Bytes below panics on nil coordinates This is fully cargo culted:
+	// I don't know if this actually occurs in production use.
+	//nolint:staticcheck
 	if key.X == nil || key.Y == nil {
 		return nil, errors.New("public key has nil XY coordinates")
 	}
 
-	// lint here suggestest using ecdh package, but we are using ecdsa key through out the code
-	// have found a straight forward to go from ecdh.P256().NewPublicKey(raw) -> ecdsa.PublicKey
-	//nolint:staticcheck
-	keyBytes := elliptic.Marshal(elliptic.P256(), key.X, key.Y)
+	keyBytes, err := key.Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("encoding public key: %w", err)
+	}
+
 	hash := sha1.New()
 	hash.Write(keyBytes)
 	return hash.Sum(nil), nil


### PR DESCRIPTION
We previously noted that a few crypto APIs were deprecated, even back in #37 we added lint excludes. I don't believe there was a way around it at the time for ecdsa, though? Go 1.26 further deprecated the `ecdsa.PublicKey` fields for `X` and `Y` after 1.25 added `ecdsa.ParseUncompressedPublicKey`, per the [changelog](https://go.dev/doc/go1.25#cryptoecdsapkgcryptoecdsa):

> The new [ParseRawPrivateKey](https://go.dev/pkg/crypto/ecdsa#ParseRawPrivateKey), [ParseUncompressedPublicKey](https://go.dev/pkg/crypto/ecdsa#ParseUncompressedPublicKey), [PrivateKey.Bytes](https://go.dev/pkg/crypto/ecdsa#PrivateKey.Bytes), and [PublicKey.Bytes](https://go.dev/pkg/crypto/ecdsa#PublicKey.Bytes) functions and methods implement low-level encodings, replacing the need to use [crypto/elliptic](https://go.dev/pkg/crypto/elliptic) or [math/big](https://go.dev/pkg/math/big) functions and methods.

I'm no cryptographer, but this looks like what's required to remove our deprecated usage, since we can now directly parse a public key from some bytes. It also ended up being a roadblock when upgrading actionlint.

Changes:
  * Swapped out `/pkg/secureenclave`'s to use the new APIs described above.
  * Added docs about working around openssl errors on MacOS.

## TPM Error
I added documentation about openssl after running into this error on TPM tests:
```
❯ go test -v -count 1 ./pkg/tpm
# github.com/google/go-tpm-tools/simulator/internal
In file included from ../../go/pkg/mod/github.com/google/go-tpm-tools@v0.3.11/simulator/internal/internal_cgo.go:45:
In file included from ../../go/pkg/mod/github.com/google/go-tpm-tools@v0.3.11/simulator/ms-tpm-20-ref/TPMCmd/tpm/include/Tpm.h:47:
In file included from ../../go/pkg/mod/github.com/google/go-tpm-tools@v0.3.11/simulator/ms-tpm-20-ref/TPMCmd/tpm/include/LibSupport.h:63:
../../go/pkg/mod/github.com/google/go-tpm-tools@v0.3.11/simulator/ms-tpm-20-ref/TPMCmd/tpm/include/Ossl/TpmToOsslSym.h:47:10: fatal error: 'openssl/aes.h' file not found
   47 | #include <openssl/aes.h>
      |          ^~~~~~~~~~~~~~~
1 error generated.
FAIL	github.com/kolide/krypto/pkg/tpm [build failed]
FAIL
```

## Test Results
Running the secureenclave tests pass:
```
=== RUN   TestSecureEnclaveTestRunner
=== PAUSE TestSecureEnclaveTestRunner
=== CONT  TestSecureEnclaveTestRunner
    secureenclave_test.go:39: 
        executing wrapped tests with codesigned app and entitlements
    secureenclave_test.go:73: === RUN   TestPublicKeyKnownGood
        === PAUSE TestPublicKeyKnownGood
        === RUN   TestPublicKeyLookUpHashNilCoordinates
        === PAUSE TestPublicKeyLookUpHashNilCoordinates
        === RUN   TestSecureEnclaveTestRunner
        === PAUSE TestSecureEnclaveTestRunner
        === RUN   TestSecureEnclaveSigning
        === PAUSE TestSecureEnclaveSigning
        === RUN   TestSecureEnclaveErrors
        === PAUSE TestSecureEnclaveErrors
        === CONT  TestPublicKeyKnownGood
        === CONT  TestSecureEnclaveErrors
        === CONT  TestSecureEnclaveSigning
        === CONT  TestPublicKeyLookUpHashNilCoordinates
        === NAME  TestSecureEnclaveErrors
            secureenclave_test.go:115: 
                running wrapped tests with codesigned app and entitlements
        === CONT  TestSecureEnclaveTestRunner
        --- PASS: TestSecureEnclaveErrors (0.00s)
        === NAME  TestSecureEnclaveSigning
            secureenclave_test.go:83: 
                running wrapped tests with codesigned app and entitlements
        === NAME  TestSecureEnclaveTestRunner
            secureenclave_test.go:36: 
                skipping because SECURE_ENCLAVE_TEST_WRAPPED env var was not empty, this is the execution of the codesigned app with entitlements
        --- SKIP: TestSecureEnclaveTestRunner (0.00s)
        --- PASS: TestPublicKeyLookUpHashNilCoordinates (0.00s)
        --- PASS: TestPublicKeyKnownGood (0.00s)
        --- PASS: TestSecureEnclaveSigning (0.03s)
        PASS
        coverage: 84.5% of statements
        
--- PASS: TestSecureEnclaveTestRunner (7.32s)
PASS
ok  	github.com/kolide/krypto/pkg/secureenclave	(cached)

```