### PR TITLE
Update go to 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kolide/krypto
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/kolide/kit v0.0.0-20221107170827-fb85e3d59eab


### PR DESCRIPTION
Updates Go to 1.26.6, following [launcher](https://github.com/kolide/launcher/pull/2795) for Go vulnerability resolution.